### PR TITLE
Added -fPIC switch to work with building Swift 4 on Linux 

### DIFF
--- a/buildlib
+++ b/buildlib
@@ -31,7 +31,7 @@ set -v
 LIB=libBlocksRuntime.a
 SRC=BlocksRuntime
 if test -f $LIB; then rm $LIB; fi
-"$CC" -c $CFLAGS -o $SRC/data.o $SRC/data.c \
-&& "$CC" -c $CFLAGS -o $SRC/runtime.o -I . $SRC/runtime.c \
+"$CC" -fPIC -c $CFLAGS -o $SRC/data.o $SRC/data.c \
+&& "$CC" -fPIC -c $CFLAGS -o $SRC/runtime.o -I . $SRC/runtime.c \
 && "$AR" cr $LIB $SRC/data.o $SRC/runtime.o \
 && "$RANLIB" $LIB


### PR DESCRIPTION
The Clang compiler wants the library to have position independent code so I added -fPIC. This makes Clang (and subsequently Swift) compile correctly.